### PR TITLE
Adds support for mqtt options

### DIFF
--- a/templates/python2/action-{{action_name}}.py.tpl
+++ b/templates/python2/action-{{action_name}}.py.tpl
@@ -3,6 +3,7 @@
 
 import ConfigParser
 from hermes_python.hermes import Hermes
+from hermes_python.ffi.utils import MqttOptions
 from hermes_python.ontology import *
 import io
 
@@ -34,6 +35,7 @@ def action_wrapper(hermes, intentMessage, conf):
 
 
 if __name__ == "__main__":
-    with Hermes("localhost:1883") as h:
+    mqtt_opts = MqttOptions()
+    with Hermes(mqtt_options=mqtt_opts) as h:
         h.subscribe_intent("{{intent_id}}", subscribe_intent_callback) \
          .start()

--- a/templates/python2/requirements.txt
+++ b/templates/python2/requirements.txt
@@ -1,3 +1,3 @@
 # Bindings for the hermes protocol 
-hermes-python>=0.1
+hermes-python>=0.2
 

--- a/templates/python3/action-{{action_name}}.py.tpl
+++ b/templates/python3/action-{{action_name}}.py.tpl
@@ -3,6 +3,7 @@
 
 import configparser
 from hermes_python.hermes import Hermes
+from hermes_python.ffi.utils import MqttOptions
 from hermes_python.ontology import *
 import io
 
@@ -34,6 +35,7 @@ def action_wrapper(hermes, intentMessage, conf):
 
 
 if __name__ == "__main__":
-    with Hermes("localhost:1883") as h:
+    mqtt_opts = MqttOptions()
+    with Hermes(mqtt_options=mqtt_opts) as h:
         h.subscribe_intent("{{intent_id}}", subscribe_intent_callback) \
          .start()

--- a/templates/python3/requirements.txt
+++ b/templates/python3/requirements.txt
@@ -1,3 +1,3 @@
 # Bindings for the hermes protocol 
-hermes-python>=0.1
+hermes-python>=0.2
 


### PR DESCRIPTION
Since version `0.2.0` we introduced the class `MqttOptions` that adds Authentication + TLS to `hermes-python`. Let's update the template accordingly. 